### PR TITLE
Docs: Add architecture ADR set for Issue #1

### DIFF
--- a/docs/adr/ADR-001-adr-format-and-storage-convention.md
+++ b/docs/adr/ADR-001-adr-format-and-storage-convention.md
@@ -1,0 +1,62 @@
+# ADR-001 — ADR Format and Storage Convention
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+Architecture Decision Records (ADRs) allow the team to document significant technical decisions as they are made, capturing the context, reasoning, and consequences in a durable and reviewable format. Without a defined convention, ADRs may be stored inconsistently, use different templates, or become hard to discover.
+
+## Decision
+
+All ADRs for this project:
+
+- Are stored under `docs/adr/` in the root of the repository.
+- Are numbered sequentially starting at `ADR-001`.
+- Use the filename pattern `ADR-NNN-short-title-in-kebab-case.md`.
+- Follow the section structure defined in this document.
+
+### Template structure
+
+```
+# ADR-NNN — Title
+
+| Field  | Value |
+|--------|-------|
+| Status | Proposed | Accepted | Deprecated | Superseded by ADR-NNN |
+| Date   | YYYY-MM-DD |
+
+## Context
+## Decision
+## Rationale
+## Alternatives Considered
+## Consequences
+```
+
+Valid status values:
+
+| Status | Meaning |
+|--------|---------|
+| Proposed | Under discussion, not yet adopted |
+| Accepted | Agreed upon and in effect |
+| Deprecated | No longer applicable |
+| Superseded by ADR-NNN | Replaced by a later decision |
+
+## Rationale
+
+- Keeping ADRs in the repository alongside code ensures decisions are version-controlled, diff-able, and discoverable.
+- A fixed template reduces cognitive overhead when writing or reviewing ADRs.
+- Sequential numbering makes cross-referencing and ordered reading straightforward.
+
+## Alternatives Considered
+
+- **Wiki or external tool (Confluence, Notion):** Decisions would not be co-located with code, creating drift and discoverability issues.
+- **Free-form prose without a template:** Harder to review and compare across decisions.
+
+## Consequences
+
+- Every significant architectural decision going forward must produce an ADR before or shortly after implementation.
+- When a decision is revised, a new ADR is created and the old one is updated to `Superseded by ADR-NNN`.
+- ADR-001 itself is self-referential and acts as the authoritative template.

--- a/docs/adr/ADR-002-api-design-style.md
+++ b/docs/adr/ADR-002-api-design-style.md
@@ -1,0 +1,34 @@
+# ADR-002 — API Design Style
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+The LX Container Weaver manager exposes an API for CRUD operations on clusters, nodes, containers, and VMs. The API is consumed exclusively by internal clients (CLI tools, dashboards, and internal services) — no third-party or public consumers are expected. The choice of API style affects developer ergonomics, tooling support, performance, and long-term maintainability.
+
+## Decision
+
+The manager API is designed as a **RESTful HTTP API** using JSON as the wire format, versioned under a `/v1/` path prefix.
+
+## Rationale
+
+- **REST is universally understood** and requires no code generation or special tooling for initial development and testing.
+- **Internal-only consumers** reduce the pressure to use gRPC for cross-language contract enforcement — all clients will be part of the same repository or ecosystem.
+- **Hetzner Cloud API and LXD API are both REST-based**, keeping the integration surface consistent and reducing the number of protocol concepts in the codebase.
+- REST over HTTPS with JSON is straightforward to inspect, debug, and document with tools like OpenAPI/Swagger.
+- Performance requirements (provisioning, scaling, migration operations) are dominated by infrastructure latency, not API serialization overhead, making gRPC's binary efficiency advantage negligible here.
+
+## Alternatives Considered
+
+- **gRPC:** Strong contract enforcement and better streaming support, but adds code generation complexity and is less ergonomic for ad hoc testing and scripting. Preferred if clients become cross-language or performance-critical.
+- **GraphQL:** Flexible querying, but adds significant complexity for an API with well-defined, bounded resource types. Overkill for this use case.
+
+## Consequences
+
+- API surface is documented with an OpenAPI specification committed to the repository.
+- All resources follow standard REST conventions: `GET`, `POST`, `PUT`/`PATCH`, `DELETE` with consistent status code usage.
+- API versioning (e.g. `/v1/`) is included from the start to allow non-breaking evolution.
+- If streaming requirements emerge (e.g. real-time node metrics), Server-Sent Events (SSE) or WebSockets may be added alongside REST without replacing it.

--- a/docs/adr/ADR-003-authentication-and-authorization-strategy.md
+++ b/docs/adr/ADR-003-authentication-and-authorization-strategy.md
@@ -1,0 +1,39 @@
+# ADR-003 — Authentication and Authorization Strategy
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+The manager API is internal-only — it is accessed by trusted clients (CLI tools, internal automation, dashboards) within a controlled network. There are no third-party or end-user consumers. The authentication mechanism must be secure, simple to operate, and not require external identity infrastructure.
+
+## Decision
+
+The manager API uses **static API keys** passed as a bearer token in the `Authorization` header.
+
+- Each client is issued a unique API key.
+- Keys are stored server-side as hashed values (bcrypt or Argon2).
+- Keys are configured via environment variables or a secrets manager (not committed to source control).
+- HTTPS/TLS is required for all API communication to protect keys in transit.
+
+## Rationale
+
+- **Simplicity:** API keys require no external identity provider, token exchange flows, or certificate infrastructure, making them operationally lightweight for an internal service.
+- **Sufficient for the threat model:** With HTTPS enforced and a controlled network boundary, API keys provide adequate security without OAuth2/OIDC complexity.
+- **Easy to rotate:** New keys can be issued and old ones revoked without redeploying clients.
+- **Audit-friendly:** Per-client keys enable request attribution in logs.
+
+## Alternatives Considered
+
+- **mTLS:** Stronger mutual authentication, but requires managing client certificates and a PKI — significant operational overhead for an internal tool.
+- **OAuth2 / OIDC:** Appropriate for user-facing or multi-tenant systems, but overly complex for a purely internal service with no user identity requirements.
+- **Shared secret (single key for all clients):** Simpler, but provides no per-client attribution and makes rotation riskier (all clients affected simultaneously).
+
+## Consequences
+
+- All API requests must include a valid `Authorization: Bearer <api-key>` header; unauthenticated requests return `401`.
+- API keys must never be committed to source control; a `.env.example` template documents required variables.
+- Key hashing, validation, and rotation logic is implemented in the manager's authentication middleware.
+- If multi-tenancy or user-facing access is added in the future, this ADR should be revisited in favour of OAuth2/OIDC.

--- a/docs/adr/ADR-004-database-technology-choice.md
+++ b/docs/adr/ADR-004-database-technology-choice.md
@@ -1,0 +1,35 @@
+# ADR-004 — Database Technology Choice
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+The manager needs to persist cluster state, node metadata, container/VM records, scheduling decisions, and provisioning history. The persistence layer must be reliable, easy to operate in a single-service deployment, and capable of supporting relational queries across entities (clusters → nodes → containers).
+
+## Decision
+
+Use **PostgreSQL** as the primary database.
+
+## Rationale
+
+- **Relational model fits the domain well:** Clusters, nodes, and containers have clear foreign-key relationships and benefit from JOIN queries and referential integrity.
+- **Proven reliability:** PostgreSQL is production-grade with strong ACID guarantees, suitable for state that must survive process restarts and partial failures.
+- **Rich ecosystem:** Mature drivers exist for all major languages (notably the Go `pgx` driver), and tooling for migrations (e.g. `golang-migrate`, `Flyway`) is well-established.
+- **Operational familiarity:** PostgreSQL is widely understood and can be run as a managed service on Hetzner (or self-hosted) with minimal configuration.
+- **Schema evolution:** Structured migrations are straightforward compared to document stores, which matters as the data model evolves.
+
+## Alternatives Considered
+
+- **SQLite:** Suitable for single-binary deployments, but poor support for concurrent writes and no network access mode makes it unsuitable for a service that may eventually scale horizontally or be accessed by multiple replicas.
+- **etcd:** Excellent for distributed consensus and leader election, but not designed for relational queries. Better suited as a coordination layer (could be added alongside PostgreSQL if needed) than a primary store.
+- **CockroachDB / distributed SQL:** Adds operational complexity without a clear current requirement for geographic distribution or extreme scale.
+
+## Consequences
+
+- PostgreSQL must be available as a dependency for running the manager (locally via Docker Compose, or as a managed instance in production).
+- Database schema changes are managed through versioned migration files under `db/migrations/`.
+- Connection pooling (e.g. PgBouncer or library-level pooling) should be configured for production deployments.
+- The data access layer is abstracted behind an interface to allow swapping the underlying database in tests or future decisions without rewriting business logic.

--- a/docs/adr/ADR-005-hyperscaler-integration-approach.md
+++ b/docs/adr/ADR-005-hyperscaler-integration-approach.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-The manager must provision and deprovision cloud servers (physical nodes) as part of its auto-scaling behaviour. The initial target hyperscaler is **Hetzner Cloud**, but the design must remain extensible to additional providers (e.g. AWS, DigitalOcean, OVH) without rewriting the orchestration logic.
+The manager must provision and deprovision cloud servers (future LXD nodes) as part of its auto-scaling behaviour. The initial target hyperscaler is **Hetzner Cloud**, but the design must remain extensible to additional providers (e.g. AWS, DigitalOcean, OVH) without rewriting the orchestration logic.
 
 Server provisioning must be idempotent, state-tracked, and recoverable in the event of a partial failure. Terraform is explicitly excluded as a dependency.
 
@@ -47,3 +47,9 @@ The Pulumi stack per-cluster manages the lifecycle of servers declared for that 
 - The `HyperscalerProvider` interface is defined in the manager codebase; the Hetzner implementation is the first concrete provider.
 - Adding a new hyperscaler requires implementing the provider interface and a corresponding Pulumi stack definition — no changes to orchestration logic.
 - Pulumi state backends (e.g. S3-compatible object store) must be configured and documented for production deployments.
+
+## Related ADRs
+
+- ADR-006 — Orchestration and Scheduling Strategy
+- ADR-008 — Multi-Cluster Management Model
+- ADR-009 — Implementation Language Choice

--- a/docs/adr/ADR-005-hyperscaler-integration-approach.md
+++ b/docs/adr/ADR-005-hyperscaler-integration-approach.md
@@ -1,0 +1,49 @@
+# ADR-005 — Hyperscaler Integration Approach
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+The manager must provision and deprovision cloud servers (physical nodes) as part of its auto-scaling behaviour. The initial target hyperscaler is **Hetzner Cloud**, but the design must remain extensible to additional providers (e.g. AWS, DigitalOcean, OVH) without rewriting the orchestration logic.
+
+Server provisioning must be idempotent, state-tracked, and recoverable in the event of a partial failure. Terraform is explicitly excluded as a dependency.
+
+## Decision
+
+Use the **Pulumi Automation API** (embedded Go library) to provision and deprovision cloud servers, with a **Hetzner Cloud provider** as the first implementation and a **provider abstraction interface** that future hyperscalers implement.
+
+The abstraction interface exposes the following operations:
+
+```
+ProvisionServer(ctx, spec) → ServerID
+DeprovisionServer(ctx, ServerID) → error
+GetServer(ctx, ServerID) → ServerInfo
+ListServers(ctx) → []ServerInfo
+```
+
+The Pulumi stack per-cluster manages the lifecycle of servers declared for that cluster.
+
+## Rationale
+
+- **Pulumi Automation API** embeds directly into a Go binary — no separate CLI, HCL, or external process required. Provisioning logic runs in-process with the manager.
+- **State management and idempotency** are handled by Pulumi natively, including drift detection and rollback on failure. This is critical in an orchestrator that may retry or crash mid-provision.
+- **Provider extensibility** is a first-class Pulumi concept — adding a new hyperscaler means implementing a new Pulumi provider stack, not rewriting provisioning logic.
+- **Hetzner Cloud** has an official Pulumi provider (`pulumi-hcloud`) that is actively maintained.
+- No Terraform: avoids the HCL DSL, Terraform binary dependency, and the operational complexity of managing a Terraform state backend separately from the manager.
+
+## Alternatives Considered
+
+- **Pure REST API (Hetzner SDK):** Lightweight and no external dependency, but requires hand-rolling state tracking, idempotency, retry logic, and a full new client for every additional hyperscaler. Does not scale to the multi-hyperscaler requirement.
+- **Terraform via `exec.Command`:** Excluded by requirement. Also introduces HCL as a second language and a binary dependency.
+- **Crossplane:** Kubernetes-native, powerful, but requires a Kubernetes control plane as a dependency — inappropriate for a standalone service.
+
+## Consequences
+
+- Pulumi Go SDK is added as a dependency (`github.com/pulumi/pulumi/sdk/v3`).
+- Each cluster has an associated Pulumi stack; stack state is stored in a configured Pulumi backend (local filesystem for development, object storage for production).
+- The `HyperscalerProvider` interface is defined in the manager codebase; the Hetzner implementation is the first concrete provider.
+- Adding a new hyperscaler requires implementing the provider interface and a corresponding Pulumi stack definition — no changes to orchestration logic.
+- Pulumi state backends (e.g. S3-compatible object store) must be configured and documented for production deployments.

--- a/docs/adr/ADR-006-orchestration-and-scheduling-strategy.md
+++ b/docs/adr/ADR-006-orchestration-and-scheduling-strategy.md
@@ -9,10 +9,10 @@
 
 The core value of LX Container Weaver is its ability to automatically manage LXD node capacity in response to workload demand. This requires a well-defined strategy for:
 
-1. Deciding where to place a new container or VM (scheduling).
+1. Deciding where to place a new instance (container or VM) (scheduling).
 2. Detecting when capacity is insufficient and provisioning more (scale-out).
 3. Detecting when capacity is over-provisioned and consolidating workloads to free nodes (scale-in).
-4. Evicting containers/VMs from a node safely before decommissioning it.
+4. Evicting instances from a node safely before decommissioning it.
 
 ## Decision
 
@@ -20,7 +20,7 @@ The orchestrator runs a **continuous reconciliation loop** that periodically eva
 
 ### Placement (scheduling)
 
-New containers and VMs are placed using a **bin-packing strategy**: select the node with the highest current utilisation that still has sufficient headroom for the workload's requested CPU, memory, and disk. This minimises fragmentation and delays scale-out.
+New instances (containers and VMs) are placed using a **bin-packing strategy**: select the node with the highest current utilisation that still has sufficient headroom for the workload's requested CPU, memory, and disk. This minimises fragmentation and delays scale-out.
 
 ### Scale-out trigger
 
@@ -63,3 +63,9 @@ On trigger: live-migrate all workloads off the candidate node (ADR-007), remove 
 - The reconciliation loop must be observable: each iteration logs decisions and reasons, and metrics are exposed for dashboarding.
 - The loop must handle partial failures gracefully (e.g. a failed provisioning attempt should not block the next iteration).
 - The scheduling algorithm is encapsulated in a replaceable `Scheduler` interface to allow alternative strategies in the future.
+
+## Related ADRs
+
+- ADR-005 — Hyperscaler Integration Approach
+- ADR-007 — Live Migration Mechanism
+- ADR-008 — Multi-Cluster Management Model

--- a/docs/adr/ADR-006-orchestration-and-scheduling-strategy.md
+++ b/docs/adr/ADR-006-orchestration-and-scheduling-strategy.md
@@ -1,0 +1,65 @@
+# ADR-006 — Orchestration and Scheduling Strategy
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+The core value of LX Container Weaver is its ability to automatically manage LXD node capacity in response to workload demand. This requires a well-defined strategy for:
+
+1. Deciding where to place a new container or VM (scheduling).
+2. Detecting when capacity is insufficient and provisioning more (scale-out).
+3. Detecting when capacity is over-provisioned and consolidating workloads to free nodes (scale-in).
+4. Evicting containers/VMs from a node safely before decommissioning it.
+
+## Decision
+
+The orchestrator runs a **continuous reconciliation loop** that periodically evaluates the state of each cluster and drives it toward the desired state. Scheduling, scale-out, consolidation, and eviction are all handled within this loop.
+
+### Placement (scheduling)
+
+New containers and VMs are placed using a **bin-packing strategy**: select the node with the highest current utilisation that still has sufficient headroom for the workload's requested CPU, memory, and disk. This minimises fragmentation and delays scale-out.
+
+### Scale-out trigger
+
+A scale-out is triggered when:
+- A new workload cannot be placed on any existing node, **or**
+- Any node's CPU or memory utilisation exceeds a configurable high-water mark (default: 80%) for a sustained period (default: 5 minutes).
+
+On trigger: provision a new server via the hyperscaler provider (ADR-005), bootstrap it as an LXD node, and add it to the cluster.
+
+### Scale-in / consolidation trigger
+
+A scale-in is triggered when:
+- One or more nodes' CPU and memory utilisation fall below a configurable low-water mark (default: 20%) for a sustained period (default: 15 minutes), **and**
+- The workloads on those nodes can be migrated to the remaining nodes without exceeding the high-water mark.
+
+On trigger: live-migrate all workloads off the candidate node (ADR-007), remove the node from the LXD cluster, and deprovision the server.
+
+### Reconciliation loop
+
+- Loop interval: configurable, default 60 seconds.
+- Each iteration reads current node metrics and workload state from LXD and the database.
+- Only one scale-out or scale-in action is taken per loop iteration per cluster to avoid oscillation.
+- A cooldown period (default: 10 minutes) is enforced after any scale-out or scale-in event before the next can be triggered.
+
+## Rationale
+
+- A reconciliation loop (rather than event-driven triggers) provides a simple, predictable, and debuggable control plane model.
+- Bin-packing placement maximises utilisation before triggering scale-out, directly reducing cloud costs.
+- Water-mark thresholds with sustained-period requirements prevent thrashing from short-lived spikes.
+- Cooldown periods prevent oscillation between scale-out and scale-in states.
+
+## Alternatives Considered
+
+- **Event-driven scheduling (react immediately to workload changes):** Lower latency, but more complex to implement, test, and reason about. Reconciliation loops are a proven pattern (Kubernetes uses the same model).
+- **Spread placement (distribute evenly across nodes):** Maximises redundancy but increases the number of nodes required, raising costs — contrary to the project's cost-efficiency goal.
+
+## Consequences
+
+- All thresholds (high-water mark, low-water mark, sustained period, cooldown) are configurable via the manager's configuration file.
+- The reconciliation loop must be observable: each iteration logs decisions and reasons, and metrics are exposed for dashboarding.
+- The loop must handle partial failures gracefully (e.g. a failed provisioning attempt should not block the next iteration).
+- The scheduling algorithm is encapsulated in a replaceable `Scheduler` interface to allow alternative strategies in the future.

--- a/docs/adr/ADR-007-live-migration-mechanism.md
+++ b/docs/adr/ADR-007-live-migration-mechanism.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-Scale-in and workload consolidation (ADR-006) require moving running containers and VMs from one LXD node to another without stopping them. Live migration must be reliable, observable, and handle failure cases gracefully to avoid data loss or unplanned downtime.
+Scale-in and workload consolidation (ADR-006) require moving running instances (containers and VMs) from one LXD node to another without stopping them. Live migration must be reliable, observable, and handle failure cases gracefully to avoid data loss or unplanned downtime.
 
 ## Decision
 
@@ -42,3 +42,8 @@ The migration flow is:
 - The manager must track in-progress migrations to avoid scheduling decisions that conflict with an ongoing move.
 - Migration timeouts and retry policies are configurable.
 - If live migration fails on a node targeted for scale-in, that node is excluded from scale-in for the current reconciliation cycle and retried in a future cycle.
+
+## Related ADRs
+
+- ADR-006 — Orchestration and Scheduling Strategy
+- ADR-008 — Multi-Cluster Management Model

--- a/docs/adr/ADR-007-live-migration-mechanism.md
+++ b/docs/adr/ADR-007-live-migration-mechanism.md
@@ -1,0 +1,44 @@
+# ADR-007 — Live Migration Mechanism
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+Scale-in and workload consolidation (ADR-006) require moving running containers and VMs from one LXD node to another without stopping them. Live migration must be reliable, observable, and handle failure cases gracefully to avoid data loss or unplanned downtime.
+
+## Decision
+
+Live migration is performed using **LXD's native live migration capability** (`lxc move <instance> <target-node> --live`) invoked via the LXD REST API.
+
+Migration is scoped to **within the same LXD cluster** only. Cross-cluster migration is explicitly out of scope for the initial version.
+
+The migration flow is:
+
+1. Select source node (candidate for scale-in) and identify all instances on it.
+2. For each instance, verify the target node has sufficient capacity.
+3. Issue the `move` operation via the LXD API.
+4. Poll the LXD API until the operation completes or times out.
+5. On success: update the manager's database to reflect the new placement.
+6. On failure: log the error, mark the migration as failed, abort scale-in for that node, and retain the instance on the source node. Alert via logs/metrics.
+
+## Rationale
+
+- **LXD's built-in live migration** handles the complexity of memory transfer, disk sync (CRIU for containers, QEMU for VMs), and state consistency. There is no benefit to implementing this at the manager level.
+- Using the **LXD REST API** (rather than the `lxc` CLI binary) keeps the manager self-contained without a runtime dependency on the CLI tool.
+- **Polling for completion** is preferred over callbacks for simplicity and compatibility with LXD's async operation model.
+
+## Alternatives Considered
+
+- **Cold migration (stop, move, start):** Simpler and more reliable, but introduces downtime — unacceptable for production workloads.
+- **Cross-cluster migration:** LXD does not natively support cross-cluster live migration; it would require exporting and re-importing instances, which is too disruptive for a live system. Deferred to a future ADR if required.
+
+## Consequences
+
+- Live migration requires LXD nodes to meet prerequisites: shared storage (e.g. Ceph) or `lxd.migration.stateful` support must be available.
+- Containers intended for live migration must be started with `--stateful` support enabled.
+- The manager must track in-progress migrations to avoid scheduling decisions that conflict with an ongoing move.
+- Migration timeouts and retry policies are configurable.
+- If live migration fails on a node targeted for scale-in, that node is excluded from scale-in for the current reconciliation cycle and retried in a future cycle.

--- a/docs/adr/ADR-008-multi-cluster-management-model.md
+++ b/docs/adr/ADR-008-multi-cluster-management-model.md
@@ -7,14 +7,14 @@
 
 ## Context
 
-LX Container Weaver is designed to manage multiple independent LXD clusters from a single manager instance. Each cluster may have its own set of nodes, containers, VMs, and scaling configuration. The management model must ensure strict isolation between clusters while allowing unified visibility and control through the manager API.
+LX Container Weaver is designed to manage multiple independent LXD clusters from a single manager instance. Each cluster may have its own set of nodes, instances (containers and VMs), and scaling configuration. The management model must ensure strict isolation between clusters while allowing unified visibility and control through the manager API.
 
 ## Decision
 
 Each LXD cluster is represented as an **isolated management domain** within the manager:
 
 - Clusters are registered in the manager's database with their own identity, LXD API endpoint(s), credentials, hyperscaler configuration, and scaling policy.
-- All API resources (nodes, containers, VMs, scaling events) are scoped to a cluster by a `cluster_id` foreign key.
+- All API resources (nodes, instances, scaling events) are scoped to a cluster by a `cluster_id` foreign key.
 - The reconciliation loop (ADR-006) runs **independently per cluster** — a failure or scaling event in one cluster does not affect others.
 - Each cluster has its own Pulumi stack for hyperscaler provisioning (ADR-005).
 - Cross-cluster operations (e.g. moving a workload between clusters) are not supported in the initial version.
@@ -56,3 +56,9 @@ DELETE /v1/clusters/{cluster_id}
 - Cluster credentials (LXD API endpoint and TLS certificates) are stored securely in the database (encrypted at rest).
 - The manager's internal concurrency model must ensure that per-cluster reconciliation goroutines are isolated and observable.
 - Cross-cluster migration or federation can be addressed in a future ADR if the requirement emerges.
+
+## Related ADRs
+
+- ADR-005 — Hyperscaler Integration Approach
+- ADR-006 — Orchestration and Scheduling Strategy
+- ADR-007 — Live Migration Mechanism

--- a/docs/adr/ADR-008-multi-cluster-management-model.md
+++ b/docs/adr/ADR-008-multi-cluster-management-model.md
@@ -1,0 +1,58 @@
+# ADR-008 — Multi-Cluster Management Model
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+LX Container Weaver is designed to manage multiple independent LXD clusters from a single manager instance. Each cluster may have its own set of nodes, containers, VMs, and scaling configuration. The management model must ensure strict isolation between clusters while allowing unified visibility and control through the manager API.
+
+## Decision
+
+Each LXD cluster is represented as an **isolated management domain** within the manager:
+
+- Clusters are registered in the manager's database with their own identity, LXD API endpoint(s), credentials, hyperscaler configuration, and scaling policy.
+- All API resources (nodes, containers, VMs, scaling events) are scoped to a cluster by a `cluster_id` foreign key.
+- The reconciliation loop (ADR-006) runs **independently per cluster** — a failure or scaling event in one cluster does not affect others.
+- Each cluster has its own Pulumi stack for hyperscaler provisioning (ADR-005).
+- Cross-cluster operations (e.g. moving a workload between clusters) are not supported in the initial version.
+
+### API structure
+
+Cluster-scoped resources follow a nested path pattern:
+
+```
+/v1/clusters/{cluster_id}/nodes
+/v1/clusters/{cluster_id}/instances
+/v1/clusters/{cluster_id}/events
+```
+
+Top-level cluster management:
+
+```
+GET    /v1/clusters
+POST   /v1/clusters
+GET    /v1/clusters/{cluster_id}
+PUT    /v1/clusters/{cluster_id}
+DELETE /v1/clusters/{cluster_id}
+```
+
+## Rationale
+
+- **Strict isolation** prevents a runaway scaling event or LXD connectivity issue in one cluster from cascading to others.
+- **Per-cluster reconciliation** is simpler to reason about and test than a global scheduler that must coordinate across cluster boundaries.
+- **Nested API paths** make the resource ownership model explicit and allow per-cluster access control to be added in the future without restructuring the API.
+
+## Alternatives Considered
+
+- **Separate manager instance per cluster:** Maximum isolation, but operational overhead scales linearly with the number of clusters. Unified visibility and configuration become difficult.
+- **Global scheduler across clusters:** Allows cross-cluster placement optimisation, but adds significant complexity and coordination overhead with no identified use case at this stage.
+
+## Consequences
+
+- The initial bootstrap always creates at least one cluster before any nodes or instances can be managed.
+- Cluster credentials (LXD API endpoint and TLS certificates) are stored securely in the database (encrypted at rest).
+- The manager's internal concurrency model must ensure that per-cluster reconciliation goroutines are isolated and observable.
+- Cross-cluster migration or federation can be addressed in a future ADR if the requirement emerges.

--- a/docs/adr/ADR-009-implementation-language-choice.md
+++ b/docs/adr/ADR-009-implementation-language-choice.md
@@ -40,3 +40,9 @@ The manager is implemented in **Go**.
 - The project structure follows standard Go conventions (`cmd/`, `internal/`, `pkg/`).
 - Contributors unfamiliar with Go are expected to follow the language conventions documented in `CONTRIBUTING.md`.
 - If a component with substantially different requirements emerges (e.g. a web dashboard), it may use a different language in a separate module — this ADR covers the manager service only.
+
+## Related ADRs
+
+- ADR-002 — API Design Style
+- ADR-005 — Hyperscaler Integration Approach
+- ADR-006 — Orchestration and Scheduling Strategy

--- a/docs/adr/ADR-009-implementation-language-choice.md
+++ b/docs/adr/ADR-009-implementation-language-choice.md
@@ -1,0 +1,42 @@
+# ADR-009 — Implementation Language Choice
+
+| Field  | Value |
+|--------|-------|
+| Status | Accepted |
+| Date   | 2026-04-17 |
+
+## Context
+
+The manager is a long-running service responsible for cluster orchestration, API serving, background reconciliation loops, and integration with LXD, PostgreSQL, and the Pulumi Automation API. The language choice affects developer ergonomics, ecosystem fit, runtime performance, operational simplicity, and long-term maintainability.
+
+## Decision
+
+The manager is implemented in **Go**.
+
+## Rationale
+
+| Criterion | Go |
+|-----------|-----|
+| LXD ecosystem | LXD is itself written in Go; the official LXD client library (`github.com/canonical/lxd`) is Go-native |
+| Pulumi Automation API | Official Go SDK (`github.com/pulumi/pulumi/sdk/v3`) — first-class support |
+| PostgreSQL | Excellent drivers (`pgx`) and migration tools (`golang-migrate`) |
+| Concurrency | Goroutines and channels are a natural fit for per-cluster reconciliation loops running in parallel |
+| Single binary deployment | Go compiles to a self-contained static binary — no runtime dependency, easy to containerise |
+| Performance | Compiled language with low memory footprint; suitable for a long-running service |
+| Operational simplicity | No interpreter, no virtual environment, straightforward cross-compilation |
+| Team familiarity | Go is widely known; tooling (`gofmt`, `go vet`, `golangci-lint`) enforces consistency automatically |
+
+## Alternatives Considered
+
+- **Rust:** Strong performance and memory safety guarantees, but significantly higher development complexity and a smaller ecosystem for LXD/Pulumi integrations. Better suited to systems programming than service orchestration.
+- **Python:** Rapid prototyping and a large library ecosystem, but dynamic typing and the GIL make concurrent reconciliation loops more complex to manage reliably. Less ergonomic for producing a deployable single binary.
+- **Java / Kotlin:** Mature ecosystems, but JVM startup time and memory overhead are unnecessary for this use case. No native LXD client library.
+- **TypeScript / Node.js:** Pulumi's primary language, but no native LXD client and event-loop concurrency is less natural for CPU-adjacent scheduling logic.
+
+## Consequences
+
+- All manager code is written in Go; the minimum supported version is tracked in `go.mod`.
+- Code style is enforced by `gofmt` and `golangci-lint` in CI.
+- The project structure follows standard Go conventions (`cmd/`, `internal/`, `pkg/`).
+- Contributors unfamiliar with Go are expected to follow the language conventions documented in `CONTRIBUTING.md`.
+- If a component with substantially different requirements emerges (e.g. a web dashboard), it may use a different language in a separate module — this ADR covers the manager service only.


### PR DESCRIPTION
## Summary
This PR adds the full architecture ADR set for Issue #1 and includes a follow-up consistency pass with ADR cross-linking for easier navigation.

## Included ADRs
- ADR-001: ADR format and storage convention
- ADR-002: API design style
- ADR-003: Authentication and authorization strategy (internal-only)
- ADR-004: Database technology choice
- ADR-005: Hyperscaler integration approach (Pulumi Automation API, no Terraform; Hetzner-first, extensible)
- ADR-006: Orchestration and scheduling strategy
- ADR-007: Live migration mechanism
- ADR-008: Multi-cluster management model
- ADR-009: Implementation language choice (Go)

## Follow-up refinements
- Added Related ADRs sections to improve discoverability and traceability.
- Normalized key terminology around instances (containers and VMs) and node/server wording.

## Issue linkage
Closes #1